### PR TITLE
why oh why

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -932,12 +932,6 @@ func createColumnDefinitionFromColumn(c *Column) *parquetschema.ColumnDefinition
 
 func (r *schema) GetSchemaDefinition() *parquetschema.SchemaDefinition {
 	return r.schemaDef
-	//def, err := parquetschema.ParseSchemaDefinition(r.schemaDef.String())
-	//if err != nil {
-	//	panic(err)
-	//}
-	//
-	//return def
 }
 
 // DataSize return the size of data stored in the schema right now

--- a/schema.go
+++ b/schema.go
@@ -931,12 +931,13 @@ func createColumnDefinitionFromColumn(c *Column) *parquetschema.ColumnDefinition
 }
 
 func (r *schema) GetSchemaDefinition() *parquetschema.SchemaDefinition {
-	def, err := parquetschema.ParseSchemaDefinition(r.schemaDef.String())
-	if err != nil {
-		panic(err)
-	}
-
-	return def
+	return r.schemaDef
+	//def, err := parquetschema.ParseSchemaDefinition(r.schemaDef.String())
+	//if err != nil {
+	//	panic(err)
+	//}
+	//
+	//return def
 }
 
 // DataSize return the size of data stored in the schema right now


### PR DESCRIPTION
## BEFORE - 27511/s
```
BenchmarkParquetConsumer-12        33078             36349 ns/op            5617 B/op        162 allocs/op
PASS
ok      github.com/clearbit/stream-utils/partitioner/writers/parquet    1.727s
```



## After - 110521/s
```
BenchmarkParquetConsumer-12       111354              9048 ns/op            2387 B/op         80 allocs/op
PASS
ok      github.com/clearbit/stream-utils/partitioner/writers/parquet    1.300s
```